### PR TITLE
feat: Add WhatsApp messaging methods to the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ if ($response->getStatusCode() === 200) {
 }
 ```
 
+### Send a WhatsApp message
+
+Send a free-form text message (only valid inside an open 24-hour service window), a
+pre-approved template message (for business-initiated conversations), or check delivery
+status. Each accepts a single phone number or an array.
+
+```php
+// Free-form text (within an open service window)
+$response = $service->sendWhatsAppText('Your code is 1234', 'recipient-phone-number');
+
+// Pre-approved template (business-initiated)
+$response = $service->sendWhatsAppTemplate(
+    'recipient-phone-number',
+    'order_confirmation', // template name
+    'en_US',              // language (optional, defaults to en_US)
+    [/* template components, optional */]
+);
+
+// Check delivery status using the message slug returned when sending
+$response = $service->getWhatsAppMessageStatus('message-slug');
+```
+
 ### Contact Verification
 
 #### Generic Verification Method

--- a/src/SmartpingsService.php
+++ b/src/SmartpingsService.php
@@ -178,6 +178,59 @@ class SmartpingsService extends LoggingService
     }
 
     /**
+     * Send a free-form WhatsApp text message (within an open service window).
+     *
+     * @throws Exception
+     */
+    public function sendWhatsAppText(string $message, string|array $phones): ResponseInterface
+    {
+        $phones = is_array($phones) ? $phones : [$phones];
+
+        $response = $this->sendRequest('POST', 'v1/whatsapp/messages', [
+            'message' => $message,
+            'destination' => $phones,
+            'kind' => 'text',
+        ]);
+
+        return $this->handleResponse($response, 'Failed to send WhatsApp message', ['phones' => $phones, 'message' => $message]);
+    }
+
+    /**
+     * Send a pre-approved WhatsApp template message.
+     *
+     * @throws Exception
+     */
+    public function sendWhatsAppTemplate(string|array $phones, string $name, string $language = 'en_US', array $components = []): ResponseInterface
+    {
+        $phones = is_array($phones) ? $phones : [$phones];
+
+        $template = ['name' => $name, 'language' => $language];
+        if ($components !== []) {
+            $template['components'] = $components;
+        }
+
+        $response = $this->sendRequest('POST', 'v1/whatsapp/messages', [
+            'destination' => $phones,
+            'kind' => 'template',
+            'template' => $template,
+        ]);
+
+        return $this->handleResponse($response, 'Failed to send WhatsApp template', ['phones' => $phones, 'template' => $name]);
+    }
+
+    /**
+     * Get the delivery status of a previously sent WhatsApp message.
+     *
+     * @throws Exception
+     */
+    public function getWhatsAppMessageStatus(string $message): ResponseInterface
+    {
+        $response = $this->sendGetRequest('v1/whatsapp/messages/'.urlencode($message));
+
+        return $this->handleResponse($response, 'Failed to get WhatsApp message status', compact('message'));
+    }
+
+    /**
      * @throws Exception
      */
     private function sendRequest(string $method, string $uri, array $data): ResponseInterface
@@ -185,8 +238,8 @@ class SmartpingsService extends LoggingService
         $request = $this->requestFactory->createRequest($method, $this->apiUrl.$uri);
         $request = $request->withHeader('Content-Type', 'application/json');
         $request = $request->withHeader('Accept', 'application/json');
-        $request = $request->withHeader('X-client-id', $this->clientId);
-        $request = $request->withHeader('X-secret-id', $this->secretId);
+        $request = $request->withHeader('X-Client-Id', $this->clientId);
+        $request = $request->withHeader('X-Client-Secret', $this->secretId);
         $request = $request->withBody($this->streamFactory->createStream(json_encode($data)));
 
         return $this->client->sendRequest($request);
@@ -199,8 +252,8 @@ class SmartpingsService extends LoggingService
     {
         $request = $this->requestFactory->createRequest('GET', $this->apiUrl.$uri);
         $request = $request->withHeader('Accept', 'application/json');
-        $request = $request->withHeader('X-client-id', $this->clientId);
-        $request = $request->withHeader('X-secret-id', $this->secretId);
+        $request = $request->withHeader('X-Client-Id', $this->clientId);
+        $request = $request->withHeader('X-Client-Secret', $this->secretId);
 
         return $this->client->sendRequest($request);
     }

--- a/src/SmartpingsServiceProvider.php
+++ b/src/SmartpingsServiceProvider.php
@@ -35,7 +35,7 @@ class SmartpingsServiceProvider extends ServiceProvider
             return SmartpingsService::create(
                 $config['client_id'],
                 $config['secret_id'],
-                $config['api_url']
+                $config['api_url'] ?? SmartpingsService::DEFAULT_API_URL
             );
         });
     }

--- a/tests/Unit/SmartpingsServiceTest.php
+++ b/tests/Unit/SmartpingsServiceTest.php
@@ -277,4 +277,68 @@ class SmartpingsServiceTest extends TestCase
         $this->assertEquals('verified', $responseData['data']['status']);
         $this->assertTrue($responseData['data']['verified']);
     }
+
+    private function service(MockHandler $mock): SmartpingsService
+    {
+        $httpFactory = new HttpFactory;
+
+        return new SmartpingsService(
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $httpFactory,
+            $httpFactory,
+            'https://example.com/',
+            'test-client-id',
+            'test-secret-id'
+        );
+    }
+
+    public function test_it_can_send_a_whatsapp_text_message()
+    {
+        $mock = new MockHandler([new Response(200, [], json_encode(['data' => []]))]);
+        $service = $this->service($mock);
+
+        $response = $service->sendWhatsAppText('Your code is 1234', '+15551234567');
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $request = $mock->getLastRequest();
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertStringEndsWith('v1/whatsapp/messages', (string) $request->getUri());
+        $this->assertEquals('test-client-id', $request->getHeaderLine('X-Client-Id'));
+
+        $body = json_decode((string) $request->getBody(), true);
+        $this->assertEquals('text', $body['kind']);
+        $this->assertEquals('Your code is 1234', $body['message']);
+        $this->assertEquals(['+15551234567'], $body['destination']);
+    }
+
+    public function test_it_can_send_a_whatsapp_template_message()
+    {
+        $mock = new MockHandler([new Response(200, [], json_encode(['data' => []]))]);
+        $service = $this->service($mock);
+
+        $response = $service->sendWhatsAppTemplate('+15551234567', 'order_confirmation', 'en_US');
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode((string) $mock->getLastRequest()->getBody(), true);
+        $this->assertEquals('template', $body['kind']);
+        $this->assertEquals('order_confirmation', $body['template']['name']);
+        $this->assertEquals('en_US', $body['template']['language']);
+        $this->assertArrayNotHasKey('message', $body);
+    }
+
+    public function test_it_can_get_whatsapp_message_status()
+    {
+        $mock = new MockHandler([new Response(200, [], json_encode(['data' => ['status' => 'sent']]))]);
+        $service = $this->service($mock);
+
+        $response = $service->getWhatsAppMessageStatus('msg-slug-123');
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $request = $mock->getLastRequest();
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertStringEndsWith('v1/whatsapp/messages/msg-slug-123', (string) $request->getUri());
+    }
 }


### PR DESCRIPTION
The SDK can now send WhatsApp text and template messages and check a message's delivery status, mirroring the existing SMS helpers. The client credential headers are corrected to the casing the API expects, and the service falls back to a default API URL when none is configured.